### PR TITLE
Web App will open directly in the login page

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
     "lang": "fr",
     "name": "Ecole Directe Plus",
     "short_name": "EDP",
-    "start_url": ".",
+    "start_url": "./app",
     "display": "standalone",
     "theme_color": "#181829",
     "background_color": "#323257",


### PR DESCRIPTION
Modified the manifest so that when you add the website on phone on the home screen or install it as an app on pc, it will directly open in the login page and not in the landing page because it's very annoying to have to click on "ouvrir l'app"